### PR TITLE
Fixed Bug introduced in commit 8247b7f

### DIFF
--- a/src/app/store/effects/stat-effects.ts
+++ b/src/app/store/effects/stat-effects.ts
@@ -20,7 +20,7 @@ import * as fromRoot from '../reducers';
 export class StatEffects {
     @Effect()
     add$: Observable<Action> = this.actions$.ofType(StatActions.ADD)
-    .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (action, state) => state)
+    .withLatestFrom(this.store$.select(fromRoot.getStatAddedCharId), (action, state) => state)
     .map((state) => this.storage.addStat(
         state.charId, state.meta.ids, state.meta.selectedId, state.stat))    
     .mergeMap((stat)  => {
@@ -49,7 +49,7 @@ export class StatEffects {
     @Effect({dispatch: false})
     saveMany: Observable<Action> = this.actions$.ofType(StatActions.SAVE_MANY)
         .map(toPayload)
-        .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (stats, meta) => {
+        .withLatestFrom(this.store$.select(fromRoot.getStatMetaCharId), (stats, meta) => {
             return {
                 stats,
                 state: meta.meta,
@@ -112,7 +112,7 @@ export class StatEffects {
     @Effect()
     remove$: Observable<Action> = this.actions$.ofType(StatActions.REMOVE)
         .map(toPayload)
-        .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (payload, meta) => {
+        .withLatestFrom(this.store$.select(fromRoot.getStatMetaCharId), (payload, meta) => {
             return {
                 charId: meta.charId,
                 ids: meta.meta.ids,
@@ -140,8 +140,14 @@ export class StatEffects {
   
     @Effect()
     update$: Observable<Action> = this.actions$.ofType(StatActions.UPDATE)
-        // .map(toPayload)
-        .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (action, state) => state)      
+        .map(toPayload)
+        .withLatestFrom(this.store$.select(fromRoot.getStatMetaCharId), (stat, state) => {
+            return {
+                charId: state.charId,
+                stat: stat,
+                meta: state.meta
+            };
+        })      
         .map((state) => {
             this.storage.setStat(state.stat)
             this.storage.setStatMetaState(state.charId, state.meta.ids, state.meta.selectedId);
@@ -163,7 +169,7 @@ export class StatEffects {
 
     @Effect({dispatch: false})
     select$: Observable<Action> = this.actions$.ofType(StatActions.SELECT)
-        .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (action, state) => state)
+        .withLatestFrom(this.store$.select(fromRoot.getStatMetaCharId), (action, state) => state)
         .map((state) => {
             this.storage.setStatMetaState(state.charId, state.meta.ids, state.meta.selectedId);
             return null;
@@ -171,7 +177,7 @@ export class StatEffects {
 
     @Effect({dispatch: false})
     unselect$: Observable<Action> = this.actions$.ofType(StatActions.UNSELECT)
-        .withLatestFrom(this.store$.select(fromRoot.getStatLateCharId), (action, state) => state)
+        .withLatestFrom(this.store$.select(fromRoot.getStatMetaCharId), (action, state) => state)
         .map((state) => {
             this.storage.setStatMetaState(state.charId, state.meta.ids, state.meta.selectedId);
             return null;

--- a/src/app/store/reducers/index.ts
+++ b/src/app/store/reducers/index.ts
@@ -45,9 +45,12 @@ export const getStatId       = createSelector(getStatState, fromStats.getSelecte
 export const getStat         = createSelector(getStatState, fromStats.getStat);
 export const getLatestStat   = createSelector(getStatState, fromStats.getLastAdded);
 export const getStatMeta     = createSelector(getStatState, fromStats.getMeta);
-export const getStatLateMeta = createSelector(getStatState, fromStats.getLatestMeta);
+export const getStatAddedMeta = createSelector(getStatState, fromStats.getAddedMeta);
 
-export const getStatLateCharId = createSelector(getCharacterId, getStatLateMeta, (charId, statMeta) => {
+export const getStatMetaCharId = createSelector(getCharacterId, getStatMeta, (charId, meta) => {
+    return { charId, meta };
+});
+export const getStatAddedCharId = createSelector(getCharacterId, getStatAddedMeta, (charId, statMeta) => {
     return { charId, stat: statMeta.stat, meta: statMeta.meta };
 })
 

--- a/src/app/store/reducers/stat-reducer.ts
+++ b/src/app/store/reducers/stat-reducer.ts
@@ -137,6 +137,6 @@ export const getStats      = createSelector(getIds, getEntities, (ids, entities)
 export const getMeta       = createSelector(getIds, getSelectedId, (ids, selectedId) => {
     return {ids, selectedId};
 });
-export const getLatestMeta = createSelector(getLastAdded, getMeta, (stat, meta) => {
+export const getAddedMeta = createSelector(getLastAdded, getMeta, (stat, meta) => {
     return {stat, meta};
 });


### PR DESCRIPTION
was incorrectly using selector getStatLatestCharId in StatEffects.UPDATE. This was causing it to pass the last stat in the 'array' as the one that was updated instead of whichever one was supposed to be updated. Added selector getStatMetaCharId as a way to get the necessary meta data to update localStorage and not pass unneccesary info. getStatLastestCharId was renamed to getStatAddedCharId for clarity.